### PR TITLE
local queryID only for v <PG14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,17 @@ DATA = pg_query_settings--0.1.sql
 
 PG_CONFIG = pg_config
 
-# Add an object file to compute a QueryID for PostgreSQL versions prior to 14.
 PGVER := $(shell $(PG_CONFIG) --version | cut -d. -f1 | tr -dc '[[:digit:]]')
-ifeq ($(PGVER), 12)
-  OBJS += pgsp_queryid.o
-endif
-ifeq ($(PGVER), 13)
-  OBJS += pgsp_queryid.o
+
+# If version not supported exit with an error message.
+ifneq ($(PGVER),$(filter $(PGVER),12 13 14 15))
+  $(error PostgreSQL $(PGVER) is not supported by this extension (v12..v15))
+else
+  # Add an object file to compute a QueryID for PostgreSQL versions prior to 14.
+  ifneq ($(PGVER),$(filter $(PGVER),14 15))
+    $(info Add QueryID computation for PostgreSQL $(PGVER))
+    OBJS += pgsp_queryid.o
+  endif
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 MODULE_big = pg_query_settings
-OBJS = pg_query_settings.o pgsp_queryid.o
+OBJS = pg_query_settings.o
 EXTENSION = pg_query_settings
 DATA = pg_query_settings--0.1.sql
 
 PG_CONFIG = pg_config
+
+# Add an object file to compute a QueryID for PostgreSQL versions prior to 14.
+PGVER := $(shell $(PG_CONFIG) --version | cut -d. -f1 | tr -dc '[[:digit:]]')
+ifeq ($(PGVER), 12)
+  OBJS += pgsp_queryid.o
+endif
+ifeq ($(PGVER), 13)
+  OBJS += pgsp_queryid.o
+endif
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/pg_query_settings.c
+++ b/pg_query_settings.c
@@ -24,8 +24,6 @@
 #include <utils/guc.h>
 #include <lib/ilist.h>
 
-#include "pgsp_queryid.h"
-
 /* This is a module :) */
 
 PG_MODULE_MAGIC;
@@ -39,6 +37,7 @@ PG_MODULE_MAGIC;
 #endif
 
 #if COMPUTE_LOCAL_QUERYID
+#include "pgsp_queryid.h"
 #include "parser/analyze.h"
 #endif
 


### PR DESCRIPTION
- include pgsp_queryid.h only for version prior to PG14
- include pgsp_queryid.o in shared library only for version prior to PG14.