### PR TITLE
Remove _PG_fini().

### DIFF
--- a/pg_query_settings.c
+++ b/pg_query_settings.c
@@ -51,7 +51,6 @@ PG_MODULE_MAGIC;
 /* Function definitions */
 
 void _PG_init(void);
-void _PG_fini(void);
 
 /* Variables */
 
@@ -384,25 +383,4 @@ _PG_init(void)
 #endif
 
   if (debug) elog(DEBUG1,"Exiting _PG_init()");
-}
-
-/*
- * Reset hooks
- */
-void
-_PG_fini(void)
-{
-
-  if (debug) elog(DEBUG1,"Entering _PG_fini()");
-
-  planner_hook = prevHook;
-  ExecutorEnd_hook = prev_ExecutorEnd;
-
-#if PG_VERSION_NUM < 130000
-  if (debug) elog(DEBUG1,"Recovering post_parse_analyze_hook");
-  post_parse_analyze_hook = prev_post_parse_analyze_hook;
-#endif
-
-  if (debug) elog(DEBUG1,"Exiting _PG_fini()");
-
 }


### PR DESCRIPTION
As explained by Julien Rouhaud in pg_stat_kcache's commit message 60944c460d:

Postgres hasn't called this function for more than a decade (even before extensions were introduced), and version 15 officially removes it so let's get rid of it too.